### PR TITLE
pending messages should be the same size as sent / recieved messages

### DIFF
--- a/desktop-app/templates/messages.html
+++ b/desktop-app/templates/messages.html
@@ -53,7 +53,7 @@
       <!-- pending messages -->
       <div ng-repeat-start="message in conversation.pending track by $index"
           class="from-me">
-        <p class="pending-message">{{message}}</p>
+        <div class="pending-message">{{message}}</div>
       </div>
 
       <div ng-repeat-end class="clear" scroll-to-last></div>


### PR DESCRIPTION
Looks like in https://github.com/tinderjs/tinder-desktop/commit/45b32488b032bd66740d68f806d5dcc6e693a870 I forgot to style the pending messages, woops!
