### PR TITLE
Use electron-builder for building/packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ This starts the app, and listens on port 5858 to allow remote debugging of the m
 
 ###### Building and packaging
 
-`gulp build:all` builds binaries for all platforms.
-
-`gulp pack:all` packages installers for all platforms.
+`gulp build:all` builds and packages for all platforms.
 
 `gulp -T` lists all available tasks, including platform-specific ones.
 


### PR DESCRIPTION
Holding on this until we have a resolution for #79. [electron-builder](https://github.com/electron-userland/electron-builder) makes sense if we're going to go the Squirrel update route, otherwise, we can use [windows-installer](https://github.com/electron/windows-installer) combined with another approach.

Closes #81.
