### PR TITLE
Handle expiring Tinder tokens

### DIFF
--- a/desktop-app/js/tinder-desktop.api.js
+++ b/desktop-app/js/tinder-desktop.api.js
@@ -20,7 +20,7 @@
           // Facebook token is still good. Get a new Tinder token.
           apiObj.login(localStorage.fbUserId, localStorage.fbToken);
         } else {
-          // Facebook token expired. Get a new Facebook token, then login.
+          // Facebook token expired. Get a new Facebook token.
           $location.path('/login');
         }
       } else {
@@ -32,8 +32,20 @@
 
     apiObj.logout = function() {
       var win = remote.getCurrentWindow();
-      localStorage.clear();
 
+      // Retain settings on logout.
+      var removeArr = [];
+      for (var i = 0; i < localStorage.length; i++){
+        if (localStorage.key(i) != 'settings') {
+          removeArr.push(localStorage.key(i));
+        }
+      }
+
+      for (var i = 0; i < removeArr.length; i++) {
+        localStorage.removeItem(removeArr[i]);
+      }
+
+      // Clear cache and cookies.
       win.webContents.session.clearCache(function(){
         win.webContents.session.clearStorageData({storages: ["cookies"]}, function(){
           win.webContents.reloadIgnoringCache();

--- a/desktop-app/js/tinder-desktop.login.js
+++ b/desktop-app/js/tinder-desktop.login.js
@@ -30,7 +30,7 @@
     };
 
     var tinderLogin = function() {
-      API.login($scope.fbAuthData['fb_id'], $scope.fbAuthData['access_token']);
+      API.login(localStorage.fbUserId, localStorage.fbToken);
     };
 
     var checkForToken = function(loginWindow, interval) {
@@ -43,6 +43,10 @@
           $scope.fbAuthData[param[0]] = param[1];
         }
         loginWindow.close();
+        localStorage.fbToken = $scope.fbAuthData['access_token'];
+        var now = Date.now()
+        var expiryTime = new Date(now + (1000 * $scope.fbAuthData['expires_in']));
+        localStorage.fbTokenExpiresAt = expiryTime;
         getFBUserId($scope.fbAuthData['access_token']);
       }
     };
@@ -53,11 +57,18 @@
           .success(function(data) {
             console.log(data);
             $scope.fbAuthData['fb_id'] = data.id;
+            localStorage.fbUserId = $scope.fbAuthData['fb_id']
             tinderLogin();
           })
           .error(function(data) {
             console.log(data);
           });
     }
+
+    var init = function () {
+      // Pop the login window if localStorage exists already
+      if(localStorage.length != 0) $scope.startLogin();
+    };
+    init();
   });
 })();

--- a/desktop-app/js/tinder-desktop.login.js
+++ b/desktop-app/js/tinder-desktop.login.js
@@ -66,8 +66,8 @@
     }
 
     var init = function () {
-      // Pop the login window if localStorage exists already
-      if(localStorage.length != 0) $scope.startLogin();
+      // Pop the login window if the user was involuntarily logged out.
+      if(localStorage.length > 1) $scope.startLogin();
     };
     init();
   });


### PR DESCRIPTION
Currently, if a Tinder token is invalid/expired, we just log the user out. 

This PR introduces the following changes:
1. Stores the Facebook auth token, expiration time, and user ID on login.
2. If the Tinder token expires, but the Facebook token is still valid, requests a new token from Tinder.
3. If the Tinder token expires, and the Facebook token is no longer valid, redirect to the login page and flash the login window. (Only if localStorage already exists / the user hasn't logged out manually)
   - If the Facebook session is active, this will grab the new token and redirect back to the landing page.
   - If the Facebook session is no longer valid, the user will need to log into Facebook again.
4. Otherwise, if something goes horribly wrong, we do a proper logout and invalidate the session/storage/cookies.
5. Retains Settings on logout, as there's nothing personally identifiable in there.

A bit of an ugly hack, open to suggestions on this one.

Closes #21, closes #2.
