### PR TITLE
Fix 'display ages' slider cut off

### DIFF
--- a/desktop-app/css/app.css
+++ b/desktop-app/css/app.css
@@ -648,7 +648,7 @@ section.range-slider {
     overflow: hidden;
     position: relative;
     width: 200px;
-    height: 18px;
+    height: 21px;
     display: inline-block;
 }
 
@@ -660,7 +660,7 @@ section.range-slider input {
     top: 0;
     width: 200px;
     outline: none;
-    height: 18px;
+    height: 21px;
 }
 
 section.range-slider input::-webkit-slider-thumb {


### PR DESCRIPTION
Top and bottom of the 'display ages' slider were cut off
