### PR TITLE
Rename messages header to matches because:

### DIFF
--- a/desktop-app/locales/en.json
+++ b/desktop-app/locales/en.json
@@ -16,7 +16,7 @@
   },
   "MESSAGES": {
     "TITLE": "Messages",
-    "MESSAGES_COUNT": "Messages ({{count}})",
+    "MATCHES_COUNT": "Matches: {{count}}",
     "UNKNOWN": "Unknown",
     "CHAT_WITH": "Chat with",
     "UNMATCH": "Unmatch",

--- a/desktop-app/locales/fr.json
+++ b/desktop-app/locales/fr.json
@@ -16,7 +16,7 @@
   },
   "MESSAGES": {
     "TITLE": "Messages",
-    "MESSAGES_COUNT": "Messages ({{count}})",
+    "MATCHES_COUNT": "Messages: {{count}}",
     "UNKNOWN": "Inconnu",
     "CHAT_WITH": "Discussion avec",
     "UNMATCH": "Supprimer Affinité",

--- a/desktop-app/locales/nl.json
+++ b/desktop-app/locales/nl.json
@@ -16,7 +16,7 @@
   },
   "MESSAGES": {
     "TITLE": "Berichten",
-    "MESSAGES_COUNT": "Berichten ({{count}})",
+    "MATCHES_COUNT": "Matches: {{count}}",
     "UNKNOWN": "Onbekend",
     "CHAT_WITH": "Gesprek met",
     "UNMATCH": "Match opheffen",

--- a/desktop-app/templates/messages.html
+++ b/desktop-app/templates/messages.html
@@ -2,7 +2,7 @@
   <div class="wrapper-menu" ng-include src="'partials/menu.html'"></div>
   <div class="wrapper-page">
     <div id="match-list" ng-class="showExtra && 'more-info'">
-      <div class="match-header" translate="MESSAGES.MESSAGES_COUNT"
+      <div class="match-header" translate="MESSAGES.MATCHES_COUNT"
          translate-values="{ count: conversationCount }">
       </div>
       <div class="scrollable-matchlist">


### PR DESCRIPTION
1. No page has a header with the title in it. This should be done via hover/select menu entry.
2. It's confusing because you might think the number means amount of messages or unread messages.

Note: French language should be updated. @run1t 
